### PR TITLE
fix: add relative path to semantic release prepare script

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -17,7 +17,7 @@
         [
             "@semantic-release/exec",
             {
-                "prepareCmd": "./prepare-release.sh ${nextRelease.version}"
+                "prepareCmd": "./scripts/prepare-release.sh ${nextRelease.version}"
             }
         ],
         [


### PR DESCRIPTION
BREAKING CHANGE: trigger semantic release initial config