### PR TITLE
Windows fix

### DIFF
--- a/com.developer.nefarious.zjoule.plugin/META-INF/MANIFEST.MF
+++ b/com.developer.nefarious.zjoule.plugin/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle:
  org.eclipse.core.resources;bundle-version="3.21.0",
  org.eclipse.ui.ide;bundle-version="3.22.300",
  org.eclipse.jface,
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.wst.wsdl.ui;bundle-version="1.3.101"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: com.developer.nefarious.zjoule.plugin
 Import-Package: 

--- a/com.developer.nefarious.zjoule.plugin/META-INF/MANIFEST.MF
+++ b/com.developer.nefarious.zjoule.plugin/META-INF/MANIFEST.MF
@@ -30,6 +30,7 @@ Export-Package:
  com.developer.nefarious.zjoule.plugin.core.events,
  com.developer.nefarious.zjoule.plugin.core.functions,
  com.developer.nefarious.zjoule.plugin.core.ui,
+ com.developer.nefarious.zjoule.plugin.core.utils,
  com.developer.nefarious.zjoule.plugin.login,
  com.developer.nefarious.zjoule.plugin.login.api,
  com.developer.nefarious.zjoule.plugin.login.events,

--- a/com.developer.nefarious.zjoule.plugin/src/com/developer/nefarious/zjoule/plugin/core/ui/ViewListener.java
+++ b/com.developer.nefarious.zjoule.plugin/src/com/developer/nefarious/zjoule/plugin/core/ui/ViewListener.java
@@ -19,6 +19,7 @@ import com.developer.nefarious.zjoule.plugin.core.functions.ClearHandler;
 import com.developer.nefarious.zjoule.plugin.core.functions.LoginHandler;
 import com.developer.nefarious.zjoule.plugin.core.functions.LogoutHandler;
 import com.developer.nefarious.zjoule.plugin.core.functions.PromptHandler;
+import com.developer.nefarious.zjoule.plugin.core.utils.SystemProvider;
 
 import jakarta.inject.Inject;
 
@@ -54,7 +55,8 @@ public class ViewListener extends ViewPart {
      */
     @Override
     public void createPartControl(final Composite parent) {
-        browser = BrowserFactory.create(parent, SWT.WEBKIT);
+    	int style = (isWindows()) ? SWT.EDGE : SWT.WEBKIT;
+        browser = BrowserFactory.create(parent, style);
         selectionListener = SelectionListener.create(browser);
         IViewRender viewRender = ViewRender.create();
         partListener = PartListener.create(browser);
@@ -74,8 +76,24 @@ public class ViewListener extends ViewPart {
 
         setUpToolbar();
     }
-
+    
     /**
+     * Checks if the current operating system is a version of Windows.
+     * <p>
+     * This method determines the operating system by checking if the string
+     * returned by {@link SystemProvider#getCurrentSystem()} contains the substring "win"
+     * (case insensitive).
+     * </p>
+     *
+     * @return {@code true} if the operating system name contains "win", indicating a Windows OS;
+     *         {@code false} otherwise.
+     * @see SystemProvider#getCurrentSystem()
+     */
+    private boolean isWindows() {
+		return SystemProvider.getCurrentSystem().toLowerCase().contains("win");
+	}
+
+	/**
      * Disposes of the view and its associated resources, including listeners and the browser.
      */
     @Override

--- a/com.developer.nefarious.zjoule.plugin/src/com/developer/nefarious/zjoule/plugin/core/utils/SystemProvider.java
+++ b/com.developer.nefarious.zjoule.plugin/src/com/developer/nefarious/zjoule/plugin/core/utils/SystemProvider.java
@@ -1,0 +1,33 @@
+package com.developer.nefarious.zjoule.plugin.core.utils;
+
+/**
+ * Utility class for providing information about the current operating system.
+ * <p>
+ * This class is designed to be used as a utility and cannot be instantiated.
+ * It provides a static method to retrieve the name of the operating system
+ * as reported by the Java Virtual Machine (JVM).
+ * </p>
+ */
+public abstract class SystemProvider {
+	
+	/**
+     * Retrieves the name of the operating system on which the JVM is currently running.
+     * <p>
+     * This method wraps the {@code System.getProperty("os.name")} call, which 
+     * provides the operating system name as a {@code String}.
+     * </p>
+     *
+     * @return the name of the operating system, such as "Windows 10", "Linux", or "Mac OS X".
+     *         The exact value is determined by the underlying JVM implementation.
+     * @see System#getProperty(String)
+     */
+	public static String getCurrentSystem() {
+		return System.getProperty("os.name");
+	}
+	
+	/**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+	private SystemProvider() { }
+
+}

--- a/com.developer.nefarious.zjoule.test/src/com/developer/nefarious/zjoule/test/core/ui/ViewListenerTest.java
+++ b/com.developer.nefarious.zjoule.test/src/com/developer/nefarious/zjoule/test/core/ui/ViewListenerTest.java
@@ -112,7 +112,6 @@ public class ViewListenerTest {
 		mockedStaticClearHandler = mockStatic(ClearHandler.class);
 		mockedStaticLogoutHandler = mockStatic(LogoutHandler.class);
 
-		mockedStaticBrowserFactory.when(() -> BrowserFactory.create(mockParent, SWT.WEBKIT)).thenReturn(mockBrowser);
 		mockedStaticSelectionListener.when(() -> SelectionListener.create(mockBrowser)).thenReturn(mockSelectionListener);
 		mockedStaticViewRender.when(ViewRender::create).thenReturn(mockViewRender);
 		mockedStaticPartListener.when(() -> PartListener.create(mockBrowser)).thenReturn(mockPartListener);
@@ -127,8 +126,10 @@ public class ViewListenerTest {
 	}
 
 	@Test
-	public void shouldPlumbPartControl() {
+	public void shouldPlumbPartControlForOtherSystems() {
 		// Arrange
+		mockedStaticBrowserFactory.when(() -> BrowserFactory.create(mockParent, SWT.WEBKIT)).thenReturn(mockBrowser);
+		
 		String mockBuildResult = "html-text";
 		when(mockViewRender.build()).thenReturn(mockBuildResult);
 

--- a/com.developer.nefarious.zjoule.test/src/com/developer/nefarious/zjoule/test/core/utils/SystemProviderTest.java
+++ b/com.developer.nefarious.zjoule.test/src/com/developer/nefarious/zjoule/test/core/utils/SystemProviderTest.java
@@ -1,0 +1,19 @@
+package com.developer.nefarious.zjoule.test.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.developer.nefarious.zjoule.plugin.core.utils.SystemProvider;
+
+public class SystemProviderTest {
+	
+	public void shouldReturnTheCurrentSystem() {
+		// Arrange
+		// Act
+		String returnValue = SystemProvider.getCurrentSystem();
+		// Assert
+		assertNotNull(returnValue);
+		assertFalse(returnValue.isBlank());
+	}
+
+}


### PR DESCRIPTION
The following changes are necessary in order to make the plugin available for Windows systems!

### **Summary of Changes**
1. **Refactored View Listener Test:**
   - Renamed the view listener test to ensure it focuses specifically on macOS and Linux environments. This likely aligns with platform-specific requirements or testing strategies.

2. **Added SystemProvider Class:**
   - Introduced a `SystemProvider` class to centralize and manage system-related definitions for the browser. This improves the modularity and maintainability of the code by abstracting system-specific logic into a reusable and **testable** utility.

3. **Fixed Web View for Windows:**
   - Adapted the web view implementation to work seamlessly on Windows systems by leveraging Edge (possibly via SWT `Browser` styles or configurations). This ensures consistent functionality across different operating systems.